### PR TITLE
Upgrade to stylelint v14 changes to avoid <The "syntax" option is no longer available.> error

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ class StylelintMixin {
         return [
             'stylelint',
             'stylelint-webpack-plugin',
+            'postcss-scss'
         ];
     }
 
@@ -39,12 +40,12 @@ class StylelintMixin {
      */
     register( settings ) {
         let defaults = {
-            configFile:  path.join( __dirname, '../../.stylelintrc.js' ),
-            context:     './resources',
-            failOnError: false,
-            files:       ['**/*.scss', '**/*.vue', '**/*.blade.php'],
-            quiet:       false,
-            syntax:      'scss',
+            configFile:   path.join( __dirname, '../../.stylelintrc.js' ),
+            context:      './resources',
+            failOnError:  false,
+            files:        ['**/*.scss', '**/*.vue', '**/*.blade.php'],
+            quiet:        false,
+            customSyntax: 'postcss-scss',
         };
 
         this.config = Object.assign( defaults, settings );
@@ -57,7 +58,7 @@ class StylelintMixin {
      */
     webpackPlugins() {
         let StyleLintPlugin = require( 'stylelint-webpack-plugin' );
-        
+
         return new StyleLintPlugin( this.config );
     }
 }


### PR DESCRIPTION
On its version 14.x, stylelint has changed the way it loads syntaxes like SCSS.

This causes the following error when using laravel-mix-stylelint:
```
The "syntax" option is no longer available. You should install an appropriate syntax, e.g. postcss-scss, and use the "customSyntax"
```
On newer versions Stylelint uses the `customSyntax` flag instead of `syntax` and has switched to make use of postcss plugins, so `postcss-scss` is now a dependency.

This patch solves this.